### PR TITLE
Fix IDEUI-341 java.lang subpackages import

### DIFF
--- a/codenvy-ext-java/src/main/java/com/codenvy/ide/ext/java/jdt/internal/core/dom/rewrite/ImportRewriteAnalyzer.java
+++ b/codenvy-ext-java/src/main/java/com/codenvy/ide/ext/java/jdt/internal/core/dom/rewrite/ImportRewriteAnalyzer.java
@@ -578,7 +578,7 @@ public final class ImportRewriteAnalyzer {
     }
 
     private boolean isImplicitImport(String qualifier) {
-        if (qualifier.startsWith(JAVA_LANG)) {
+        if (JAVA_LANG.equals(Signature.getQualifier(qualifier))) {
             return true;
         }
         // TODO

--- a/codenvy-ext-java/src/main/java/com/codenvy/ide/ext/java/jdt/internal/corext/util/ModelUtil.java
+++ b/codenvy-ext-java/src/main/java/com/codenvy/ide/ext/java/jdt/internal/corext/util/ModelUtil.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.codenvy.ide.ext.java.jdt.internal.corext.util;
 
+import com.codenvy.ide.ext.java.jdt.core.Signature;
 import com.codenvy.ide.ext.java.jdt.core.dom.CompilationUnit;
 
 /**
@@ -18,7 +19,7 @@ import com.codenvy.ide.ext.java.jdt.core.dom.CompilationUnit;
  */
 public class ModelUtil {
     public static boolean isImplicitImport(String string, CompilationUnit fCompilationUnit) {
-        if ("java.lang".equals(string)) {
+        if ("java.lang".equals(Signature.getQualifier(string))) {
             return true;
         }
         return false;


### PR DESCRIPTION
Limit the restriction of implicit package to strict java.lang one, not
its subpackages (for instance java.lang.reflect can now be import on
proposal completion).
