### PR TITLE
IDEX-1880 IDEX 1891 Use cloneNode instead of innerHTML+outerHTML

### DIFF
--- a/codenvy-ext-java/src/main/java/com/codenvy/ide/ext/java/client/editor/ProblemAnnotation.java
+++ b/codenvy-ext-java/src/main/java/com/codenvy/ide/ext/java/client/editor/ProblemAnnotation.java
@@ -100,7 +100,7 @@ public class ProblemAnnotation extends Annotation implements JavaAnnotation, Qui
 
         final Element selectedImageElement = getSelectedImageElement();
         if (selectedImageElement != null) {
-            fImageElement.setInnerHTML(selectedImageElement.getOuterHTML());
+            fImageElement.appendChild(selectedImageElement.cloneNode(true));
         }
     }
 


### PR DESCRIPTION
Issues in Safari on innerHTML with SVG content.
Using cloneNode instead should not be a performance issue (actually,
come tests seem to prove it's faster)