### PR TITLE
Enabling jax-rs and jax-ws support on Eclipse Che

### DIFF
--- a/codenvy-ext-maven/src/main/java/org/eclipse/che/ide/extension/maven/client/MavenExtension.java
+++ b/codenvy-ext-maven/src/main/java/org/eclipse/che/ide/extension/maven/client/MavenExtension.java
@@ -74,7 +74,9 @@ public class MavenExtension {
         archetypes =
                 Collections.createArray(new MavenArchetype("org.apache.maven.archetypes", "maven-archetype-quickstart", "RELEASE", null),
                                         new MavenArchetype("org.apache.maven.archetypes", "maven-archetype-webapp", "RELEASE", null),
-                                        new MavenArchetype("org.apache.openejb.maven", "tomee-webapp-archetype", "1.7.1", null));
+                                        new MavenArchetype("org.apache.openejb.maven", "tomee-webapp-archetype", "1.7.1", null),
+                                        new MavenArchetype("org.apache.cxf.archetype", "cxf-jaxws-javafirst", "RELEASE", null),
+                                        new MavenArchetype("org.apache.cxf.archetype", "cxf-jaxrs-service", "RELEASE", null));
     }
 
     public static Array<MavenArchetype> getAvailableArchetypes() {


### PR DESCRIPTION
This is for wso2-developer-studio 4.0.0- M1 release requirement, to provide Jax-RS and Jax-WS support in Eclipse Che